### PR TITLE
Fixing crash when reading a non FEA model or run file with bad include.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/bulk/test/pyNastran_crash.bdf

--- a/bulk/bulk.py
+++ b/bulk/bulk.py
@@ -43,9 +43,17 @@ class Bulk(BDF):
         try:
             # reading a full-run model
             self.read_bdf(bulk_filename)
+
         except RuntimeError:
-            # reading a model-only model
-            self.read_bdf(bulk_filename, punch=True)
+            try:
+                # reading a model-only model
+                self.read_bdf(bulk_filename, punch=True)
+            except RuntimeError:
+                # no fea model
+                print('Trying to read an non FEA model')
+        except IOError as io_err:
+            # bad model include in run file
+            print(f'include error: {io_err.args[0]}')
 
         # get 2D parts with self.part_2d method
         self._get_part_2d()

--- a/bulk/bulk.py
+++ b/bulk/bulk.py
@@ -23,6 +23,9 @@ class Bulk(BDF):
         # Initialize BDF class
         super().__init__()
 
+        # initialize read statement
+        self.read_statement = ""
+
         # store 2D parts
         self.part_2d = {}
         # store fasteners
@@ -43,21 +46,24 @@ class Bulk(BDF):
         try:
             # reading a full-run model
             self.read_bdf(bulk_filename)
+            self.read_statement = "full-run"
         except RuntimeError:
             try:
                 # reading a model-only model
                 self.read_bdf(bulk_filename, punch=True)
+                self.read_statement = "model-only"
             except RuntimeError:
-                # no fea model
-                print('Trying to read an non FEA model')
+                # non FEA model
+                print('FATAL ERROR: Trying to read an non FEA model')
         except IOError as io_err:
             # bad model include in run file
-            print(f'include error: {io_err.args[0]}')
+            print(f'FATAL ERROR: {io_err.args[0]}')
 
-        # get 2D parts with self.part_2d method
-        self._get_part_2d()
-        # set self.fasteners with method self._get_fasteners
-        # set self.junctions with method self._get_junctions
+        if self.read_statement:
+            # get 2D parts with self.part_2d method
+            self._get_part_2d()
+            # set self.fasteners with method self._get_fasteners
+            # set self.junctions with method self._get_junctions
 
     def _get_part_2d(self):
         """

--- a/bulk/bulk.py
+++ b/bulk/bulk.py
@@ -43,7 +43,6 @@ class Bulk(BDF):
         try:
             # reading a full-run model
             self.read_bdf(bulk_filename)
-
         except RuntimeError:
             try:
                 # reading a model-only model

--- a/bulk/test/test_bulk.py
+++ b/bulk/test/test_bulk.py
@@ -47,3 +47,15 @@ class TestReadBulk(TestCase):
         bdf_filename = os.path.join(test_path, 'FEM-001-run-include.dat')
         self.bulk = Bulk()
         self.bulk.read_bulk(bdf_filename)
+
+    def test_read_run_bad_include(self):
+        test_path = os.path.join('..', '..', 'models', 'FEM-001')
+        bdf_filename = os.path.join(test_path, 'FEM-001-run-bad-include.dat')
+        self.bulk = Bulk()
+        self.bulk.read_bulk(bdf_filename)
+
+    def test_read_no_fea_model(self):
+        test_path = os.path.join('..', '..', 'models', 'dummy')
+        bdf_filename = os.path.join(test_path, 'non-model-file.txt')
+        self.bulk = Bulk()
+        self.bulk.read_bulk(bdf_filename)

--- a/models/FEM-001/FEM-001-run-bad-include.dat
+++ b/models/FEM-001/FEM-001-run-bad-include.dat
@@ -1,0 +1,18 @@
+SOL 101
+CEND
+$ Direct Text Input for Global Case Control Data
+TITLE = MSC.Nastran job created on 18-Oct-22 at 16:54:19
+ECHO = NONE
+SUBCASE 1
+   SUBTITLE=Default
+   DISPLACEMENT(SORT1,REAL)=ALL
+   SPCFORCES(SORT1,REAL)=ALL
+   STRESS(SORT1,REAL,VONMISES,BILIN)=ALL
+$ Direct Text Input for this Subcase
+BEGIN BULK
+$ Direct Text Input for Bulk Data
+PARAM   PRTMAXIM YES
+$
+include'FEM-001-model.bdf'
+$
+ENDDATA

--- a/models/dummy/non-model-file.txt
+++ b/models/dummy/non-model-file.txt
@@ -1,0 +1,1 @@
+This file is not a FEA model.


### PR DESCRIPTION
Method read_file of class Bulk updated to avoid script crash when trying to read an non FEA model or a run file with a bad include of bulk.

Error messages are printed.

fixes #13 